### PR TITLE
task/taxonomy-service Create taxonomy endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,86 @@
 # Mid Ohio Food bank API
 
 ## Product Description and requirements
+
 [Requirements](https://github.com/SCODEMeetup/mofb-api/blob/master/product-spec.md)
 
 ## Pre-requisites
+
 1. Install Node.js from [installer](https://nodejs.org/en/)
 2. Or using [command line](https://nodejs.org/en/download/package-manager/)
 
 ## Build / Run
+
 1. Run `npm i` to install all node modules
 2. Start server using
+
 ```bash
 $ npm run start
 ```
+
 3. Server runs at localhost:3000
-```
-NOTES:
-° All queries default limit to 100. If you want more results returned than that, you must pass in the limit query parameter.
-° All queries support grabbing the next page of data. Just pass in the query parameter pageNumber=#
- ```
-   1. Bring all pantries - http://localhost:3000/api/v1/pantries
-   2. Limit to a zip code - http://localhost:3000/api/v1/pantries/43215
 
 ## Docker build
+
 1. Run `npm i` to install all node modules
 2. Run `docker-compose build` to build the image
 3. Run `docker-compose up` to start image
-4. Server runs at localhost:3000, access via http://localhost:3000/api/v1/pantries
-5. To access the swagger documentation navigate to http://localhost:3000/api-docs or http://{env}/api-docs/
-
+4. To access the swagger documentation navigate to http://localhost:3000/api-docs or http://{env}/api-docs/
 
 ## Tech Stack
+
 1. Node.js
 2. Express
 
 ## Tools
+
 1. [VSCode](https://code.visualstudio.com/)
 
 ## Adding a new endpoint
+
 1. Create the endpoint in router file
-2. If necessary, import the router file in server.js
-3. Create the swagger documentation (see swagger.yaml file)
+2. Write test for endpoint
+3. If necessary, import the router file in server.js
+4. Create the swagger documentation (see swagger.yaml file)
 
 ## Environment
+
 GCP (google cloud platform)
+
 1. Pantries - https://mofb-api.appspot.com/pantries
 2. Swagger documentation - https://mofb-api.appspot.com/api-docs/
 
 ## Data
+
 1. taxonomy.csv: This dataset explains the taxonomy codes applicable to different types of
-services
-https://ckan.smartcolumbusos.com/dataset/food-pantry-and-user-data/resource/371dd944-411c-4851-a065-9f3f605ddfb9
+   services
+   https://ckan.smartcolumbusos.com/dataset/food-pantry-and-user-data/resource/371dd944-411c-4851-a065-9f3f605ddfb9
 2. agency.csv: This dataset identifies the locations of agencies across Central Ohio region
-https://ckan.smartcolumbusos.com/dataset/food-pantry-and-user-data/resource/570a8e02-fb0e-4cee-895b-3b32bd740650
+   https://ckan.smartcolumbusos.com/dataset/food-pantry-and-user-data/resource/570a8e02-fb0e-4cee-895b-3b32bd740650
 3. service_taxonomy.csv : This dataset presents the details about the taxonomy codes applicable
-to each agency. In other words, services offered at each agency are presented
-https://ckan.smartcolumbusos.com/dataset/food-pantry-and-user-data/resource/2a919af7-12d3-47a4-b86a-56692e2e1623
+   to each agency. In other words, services offered at each agency are presented
+   https://ckan.smartcolumbusos.com/dataset/food-pantry-and-user-data/resource/2a919af7-12d3-47a4-b86a-56692e2e1623
 4. service_location.csv : This dataset contains additional information about the service locations,
-such as hours of operation:
-https://ckan.smartcolumbusos.com/dataset/b0390b58-35c9-45e8-8a2d-d2472b20d65f/resource/ec24773c-7cff-4589-9e2f-bcdeb5cdfd48/download/service_location.csv
+   such as hours of operation:
+   https://ckan.smartcolumbusos.com/dataset/b0390b58-35c9-45e8-8a2d-d2472b20d65f/resource/ec24773c-7cff-4589-9e2f-bcdeb5cdfd48/download/service_location.csv
 5. Images
-    1. ![Services aka Taxonomies with subcategories as graph](/extra/services-taxanomy-hierarchy.png)
-    2. ![Services aka Taxonomies with subcategories as table](/extra/services-hierarchy-table.png)
-    3. ![Agency and Services relation](/extra/agency-services-relation.png)
+
+   1. ![Services aka Taxonomies with subcategories as graph](/extra/services-taxanomy-hierarchy.png)
+   2. ![Services aka Taxonomies with subcategories as table](/extra/services-hierarchy-table.png)
+   3. ![Agency and Services relation](/extra/agency-services-relation.png)
 
 6. Queries
-    1. Generating services hierarchy with its categories
-        ```
-            SELECT        _TAXON_ID_, _TAXONOMY_CODE_, _DESCRIPTION_, _TAXONOMY_LEVEL_, _TAXON_ID_SUBCAT_OF_
-            FROM            dbo.taxonomy
-            WHERE        (_ACTIVE_FLAG_ = N'Y') AND (_TAXONOMY_CODE_ = N'B') OR
-                                    (_ACTIVE_FLAG_ = N'Y') AND (_TAXONOMY_CODE_ LIKE N'%BD%')
-            ORDER BY _TAXONOMY_CODE_
-        ```
-    2. Getting one service
-        ```
-            To query each individual point use this and swap out the Description as needed: SELECT  _TAXON_ID_, _TAXONOMY_CODE_, _DESCRIPTION_, _TAXONOMY_LEVEL_, _TAXON_ID_SUBCAT_OF_
-            FROM            dbo.taxonomy
-            WHERE        (_ACTIVE_FLAG_ = N'Y') AND (_DESCRIPTION_ = N'FOOD')
-        ```
+   1. Generating services hierarchy with its categories
+      ```
+          SELECT        _TAXON_ID_, _TAXONOMY_CODE_, _DESCRIPTION_, _TAXONOMY_LEVEL_, _TAXON_ID_SUBCAT_OF_
+          FROM            dbo.taxonomy
+          WHERE        (_ACTIVE_FLAG_ = N'Y') AND (_TAXONOMY_CODE_ = N'B') OR
+                                  (_ACTIVE_FLAG_ = N'Y') AND (_TAXONOMY_CODE_ LIKE N'%BD%')
+          ORDER BY _TAXONOMY_CODE_
+      ```
+   2. Getting one service
+      ```
+          To query each individual point use this and swap out the Description as needed: SELECT  _TAXON_ID_, _TAXONOMY_CODE_, _DESCRIPTION_, _TAXONOMY_LEVEL_, _TAXON_ID_SUBCAT_OF_
+          FROM            dbo.taxonomy
+          WHERE        (_ACTIVE_FLAG_ = N'Y') AND (_DESCRIPTION_ = N'FOOD')
+      ```

--- a/api/controllers/routes/taxonomy.js
+++ b/api/controllers/routes/taxonomy.js
@@ -12,7 +12,7 @@ const uri = `${host}/api/3/action/datastore_search_sql?sql=SELECT * from "${reso
 
 app.get("/", function (req, res) {
     const level = req.query.level;
-    let levelQuery = ` WHERE "TAXONOMY_LEVEL" = ${level}`;
+    const levelQuery = ` WHERE "TAXONOMY_LEVEL" = ${level}`;
 
     requestUtils.sendRequest(queryUtils.getQueryString(req, level ? uri + levelQuery : uri), res);
 });

--- a/api/controllers/routes/taxonomy.js
+++ b/api/controllers/routes/taxonomy.js
@@ -1,0 +1,28 @@
+const express = require("express");
+const app = express();
+const requestUtils = require("../../utils/request");
+const queryUtils = require("../../utils/query");
+
+const env = process.env.NODE_ENV || 'development';
+
+const config = require("../../../config")[env];
+const host = config.host;
+const resourceId = config.taxonomy_resource;
+const uri = `${host}/api/3/action/datastore_search_sql?sql=SELECT * from "${resourceId}"`;
+
+app.get("/", function (req, res) {
+    const level = req.query.level;
+    let levelQuery = ` WHERE "TAXONOMY_LEVEL" = ${level}`;
+
+    requestUtils.sendRequest(queryUtils.getQueryString(req, level ? uri + levelQuery : uri), res);
+});
+
+app.get("/basic-needs", function (_req, res) {
+    requestUtils.sendRequest(uri + 'WHERE "TAXONOMY_CODE" LIKE N\'B%\'', res);
+});
+
+app.get("/:id", function (req, res) {
+    requestUtils.sendRequest(uri + `WHERE "TAXON_ID" = ${req.params.id}`, res);
+});
+
+module.exports = app;

--- a/api/utils/query.js
+++ b/api/utils/query.js
@@ -1,0 +1,11 @@
+const requestUtils = require("./request");
+
+module.exports = {
+    getQueryString: function (req, uri) {
+        const {
+            offset,
+            limit
+        } = requestUtils.getPagingParams(req);
+        return uri + ` OFFSET ${offset} ROWS LIMIT ${limit}`;
+    }
+}

--- a/api/utils/request.js
+++ b/api/utils/request.js
@@ -1,0 +1,48 @@
+const request = require("request");
+
+module.exports = {
+    getPagingParams: function (req) {
+        const limit = req.query.limit || 100;
+        const pageNumber = req.query.pageNumber || 1;
+
+        const offset = limit * (pageNumber - 1);
+        return {
+            offset,
+            limit
+        }
+    },
+    getRequestUri: function (req, uri, params) {
+        const {
+            offset,
+            limit
+        } = this.getPagingParams(req);
+        let requestUri = uri + `&offset=${offset}&limit=${limit}`;
+        if (params) {
+            requestUri = `${requestUri}&${params}`;
+        }
+        return requestUri;
+    },
+    sendRequest: function (uri, res) {
+        const options = {
+            body: {},
+            headers: {
+                "Content-Type": "application/json"
+            },
+            json: true,
+            method: "GET",
+            uri
+        };
+
+        request(options, function (error, response, body) {
+            console.log("statusCode:", response && response.statusCode);
+            if (error || !body.success) {
+                Object.keys(body.error).forEach(key => {
+                    console.log(key + ": " + body.error[key]);
+                });
+                res.status(400).send("Could not complete request");
+            } else {
+                res.send(body.result.records);
+            }
+        });
+    }
+}

--- a/config.js
+++ b/config.js
@@ -1,4 +1,6 @@
 const config = {
+    test_env: "test",
+    test_port: 3001,
     development: {
         host: "https://ckan.smartcolumbusos.com/",
         pantry_resource: "570a8e02-fb0e-4cee-895b-3b32bd740650",

--- a/config.js
+++ b/config.js
@@ -1,11 +1,13 @@
 const config = {
     development: {
         host: "https://ckan.smartcolumbusos.com/",
-        resourceId: "570a8e02-fb0e-4cee-895b-3b32bd740650",
+        pantry_resource: "570a8e02-fb0e-4cee-895b-3b32bd740650",
+        taxonomy_resource: "371dd944-411c-4851-a065-9f3f605ddfb9"
     },
     test: {
         host: "https://ckan.smartcolumbusos.com/",
-        resourceId: "570a8e02-fb0e-4cee-895b-3b32bd740650",
+        pantry_resource: "570a8e02-fb0e-4cee-895b-3b32bd740650",
+        taxonomy_resource: "371dd944-411c-4851-a065-9f3f605ddfb9"
     }
 };
 

--- a/server.js
+++ b/server.js
@@ -8,7 +8,11 @@ const swaggerDocument = YAML.load('./swagger.yaml');
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 const pantryRouter = require('./api/controllers/routes/pantries');
+const taxonomyRouter = require('./api/controllers/routes/taxonomy');
+
 app.use('/api/v1/pantries', pantryRouter);
+app.use('/api/v1/taxonomy', taxonomyRouter);
+
 
 app.listen(port);
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,28 +1,28 @@
-swagger: '2.0'
+swagger: "2.0"
 info:
-  title: 'Mid Ohio Food Bank RESTful API'
-  description: ''
-  version: '0.0.2'
+  title: "Mid Ohio Food Bank RESTful API"
+  description: ""
+  version: "0.0.2"
   contact:
-    name: 'Report an Issue'
-    url: 'https://github.com/SCODEMeetup/mofb-api/issues'
+    name: "Report an Issue"
+    url: "https://github.com/SCODEMeetup/mofb-api/issues"
 servers:
-  - url: 'http://localhost:3000'
-    description: 'running locally'
-  - url: 'https://mofb-api.appspot.com'
-    description: 'Production server'  
-basePath: '/api/v1'
+  - url: "http://localhost:3000"
+    description: "running locally"
+  - url: "https://mofb-api.appspot.com"
+    description: "Production server"
+basePath: "/api/v1"
 paths:
   /pantries:
     get:
       tags:
-        - 'Pantries'
-      summary: 'returns a list of pantries'
+        - "Pantries"
+      summary: "returns a list of pantries"
       parameters:
         - name: limit
           in: query
           required: false
-          description: 'The maximum number of results returned'
+          description: "The maximum number of results returned"
           schema:
             type: integer
             format: int64
@@ -31,32 +31,32 @@ paths:
         - name: pageNumber
           in: query
           required: false
-          description: 'The page number of the data to be returned'
+          description: "The page number of the data to be returned"
           schema:
             type: integer
             format: int64
             minimum: 1
             default: 1
-      responses: 
-        '200':
-          description: 'Successfully queries the smart city datasets and returns the results'
+      responses:
+        "200":
+          description: "Successfully queries the smart city datasets and returns the results"
   /pantries/{zipCode}:
     get:
       tags:
-        - 'Pantries'
-      summary: 'returns a list of pantries within that zipcode'
+        - "Pantries"
+      summary: "returns a list of pantries within that zipcode"
       parameters:
         - name: zipCode
           in: path
           required: true
-          description: 'The zip code for food pantry search area'
+          description: "The zip code for food pantry search area"
           schemea:
             type: integer
             format: int64
         - name: limit
           in: query
           required: false
-          description: 'The maximum number of results returned'
+          description: "The maximum number of results returned"
           schema:
             type: integer
             format: int64
@@ -65,44 +65,96 @@ paths:
         - name: pageNumber
           in: query
           required: false
-          description: 'The page number of the data to be returned'
+          description: "The page number of the data to be returned"
           schema:
             type: integer
             format: int64
             minimum: 1
             default: 1
-      responses: 
-        '200':
-          description: 'Successfully queries the smart city datasets and returns the results'
+      responses:
+        "200":
+          description: "Successfully queries the smart city datasets and returns the results"
   /query/pantries:
     get:
       tags:
-        - 'Query'
-      summary: 'returns a list of pantries'
-      description: 'This returns the entire list of pantries. There is no pagination'
+        - "Query"
+      summary: "returns a list of pantries"
+      description: "This returns the entire list of pantries. There is no pagination"
       parameters:
         - name: currentlyActive
           in: query
           required: false
-          description: 'only return the active pantries'
+          description: "only return the active pantries"
           type: boolean
         - name: handicapAccessible
           in: query
           required: false
-          description: 'only return the pantries that are handicap accessible'
+          description: "only return the pantries that are handicap accessible"
           type: boolean
         - name: limit
           in: query
           required: false
-          description: 'set a limit to how many results are returned'
+          description: "set a limit to how many results are returned"
           schema:
             type: integer
             format: int64
             minimum: 1
-      responses: 
-        '200':
-          description: 'Successfully queries the smart city datasets and returns the results'
-  
+      responses:
+        "200":
+          description: "Successfully queries the smart city datasets and returns the results"
+  /taxonomy:
+    get:
+      tags:
+        - "Taxonomy"
+      summary: "Returns a list of Service Categories (taxonomies)"
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: "The maximum number of results returned"
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            default: 100
+        - name: pageNumber
+          in: query
+          required: false
+          description: "The page number of the data to be returned"
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            default: 1
+      responses:
+        "200":
+          description: "Successfully queries the smart city datasets and returns the results"
+  /taxonomy/{id}:
+    get:
+      tags:
+        - "Taxonomy"
+      summary: "Returns Taxonomy record for the given ID"
+      parameters:
+        - name: ID
+          in: path
+          required: true
+          description: "The ID of the taxonomy to return"
+          schemea:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: "Successfully queries the smart city datasets and returns the results"
+  /taxonomy/basic-needs:
+    get:
+      tags:
+        - "Taxonomy"
+      summary: 'Returns a list of service categories under the "Basic Needs" category'
+      description: "This returns the entire list of basic needs categories. There is no pagination"
+      responses:
+        "200":
+          description: "Successfully queries the smart city datasets and returns the results"
+
 externalDocs:
-  description: 'Find out more about the API'
-  url: 'https://github.com/SCODEMeetup/mofb-api'
+  description: "Find out more about the API"
+  url: "https://github.com/SCODEMeetup/mofb-api"

--- a/test/pantries.js
+++ b/test/pantries.js
@@ -1,11 +1,13 @@
-process.env.NODE_ENV = 'test';
-process.env.PORT = 3001;
+const config = require('../config');
 
-let chai = require('chai');
-let chaiHttp = require('chai-http');
-let server = require('../server');
+process.env.NODE_ENV = config.test_env;
+process.env.PORT = config.test_port;
 
-let should = chai.should();
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const server = require('../server');
+
+const should = chai.should();
 
 chai.use(chaiHttp);
 

--- a/test/taxonomy.js
+++ b/test/taxonomy.js
@@ -6,13 +6,14 @@ let chaiHttp = require('chai-http');
 let server = require('../server');
 
 let should = chai.should();
+let expect = chai.expect;
 
 chai.use(chaiHttp);
 
-describe('Pantries', () => {
-    it('should GET pantries limit 100', (done) => {
+describe('Taxonomy', () => {
+    it('should GET taxonomies limit 100', (done) => {
         chai.request(server)
-            .get('/api/v1/pantries')
+            .get('/api/v1/taxonomy')
             .end((err, res) => {
                 res.should.have.status(200);
                 res.body.should.be.a('array');
@@ -21,24 +22,26 @@ describe('Pantries', () => {
             });
     });
 
-    it('should GET pantries with limit of 5', (done) => {
+    it('should GET taxonomy with ID 10', (done) => {
         chai.request(server)
-            .get('/api/v1/pantries?limit=5')
+            .get('/api/v1/taxonomy/10')
             .end((err, res) => {
                 res.should.have.status(200);
-                res.body.should.be.a('array');
-                res.body.length.should.be.eql(5);
+                const tax = res.body[0];
+                tax.TAXON_ID.should.be.eql('10');
                 done();
             });
     });
 
-    it('should GET pantries by zip code', (done) => {
+    it('should GET taxonomy with under basic needs category', (done) => {
         chai.request(server)
-            .get('/api/v1/pantries/43228?limit=1')
+            .get('/api/v1/taxonomy/basic-needs')
             .end((err, res) => {
                 res.should.have.status(200);
-                const pantry = res.body[0];
-                pantry.ZIP.should.be.eql(43228);
+                res.body.should.be.a('array');
+                res.body.forEach(tax => {
+                    expect(tax.TAXONOMY_CODE).to.match(/^B.*$/);
+                });
                 done();
             });
     });

--- a/test/taxonomy.js
+++ b/test/taxonomy.js
@@ -1,12 +1,14 @@
-process.env.NODE_ENV = 'test';
-process.env.PORT = 3001;
+const config = require('../config');
 
-let chai = require('chai');
-let chaiHttp = require('chai-http');
-let server = require('../server');
+process.env.NODE_ENV = config.test_env;
+process.env.PORT = config.test_port;
 
-let should = chai.should();
-let expect = chai.expect;
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const server = require('../server');
+
+const should = chai.should();
+const expect = chai.expect;
 
 chai.use(chaiHttp);
 


### PR DESCRIPTION
Added taxonomy service endpionts
- I opted not to structure the results as a b-tree, as this is more of a data tier service and those types of transformations can be done at a business level service tier. We can add a utility method if we like
- Included paged query of all service categories, all basic needs categories, and category by ID endpoints, along with tests

Refactored for reuse
Updated README and Swagger
- Since we are adding more endpoints to the API, it felt like we should allow the swagger to document the API rather than the README, so I removed the specific "pantries" API info
- Most of the changes were due to autoformatting in VS Code to default standards, suggest all developers use this so format matches across all PRs.

Updated tests to run on port 3001 so tests and server can run simultaneously.