### PR TITLE
Task/68 endpoint to get service children

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,6 +4,3 @@ PORT=8000
 LOG_LEVEL=info
 
 SCOS_HOST=https://data.smartcolumbusos.com
-
-AGENCIES_TABLE=handson_central_ohio__community_services_agencies
-CATEGORIES_TABLE=handson_central_ohio__handson_central_ohio_agency_subcategory_terms

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,3 @@ PORT=8000
 LOG_LEVEL=debug
 
 SCOS_HOST=https://data.smartcolumbusos.com
-
-AGENCIES_TABLE=handson_central_ohio__community_services_agencies
-CATEGORIES_TABLE=handson_central_ohio__handson_central_ohio_agency_subcategory_terms

--- a/.env.production
+++ b/.env.production
@@ -4,6 +4,3 @@ PORT=8000
 LOG_LEVEL=info
 
 SCOS_HOST=https://data.smartcolumbusos.com
-
-AGENCIES_TABLE=handson_central_ohio__community_services_agencies
-CATEGORIES_TABLE=handson_central_ohio__handson_central_ohio_agency_subcategory_terms

--- a/api/controllers/index.ts
+++ b/api/controllers/index.ts
@@ -1,3 +1,4 @@
 import healthController from './healthController';
+import taxonomyController from './taxonomyController';
 
-export default [healthController];
+export default [healthController, taxonomyController];

--- a/api/controllers/taxonomyController.ts
+++ b/api/controllers/taxonomyController.ts
@@ -1,0 +1,17 @@
+import { Path, GET, PathParam } from 'typescript-rest';
+import { Tags } from 'typescript-rest-swagger';
+import TaxonomyDto from '../models/dto/taxonomyDto';
+import { getSubcategories } from '../services/taxonomyService';
+
+@Path('/api/taxonomy')
+@Tags('Taxonomy')
+export default class TaxonomyController {
+  /**
+   * Returns status of the API.
+   */
+  @GET
+  @Path('/:id/children')
+  async getSubcategories(@PathParam('id') id: string): Promise<TaxonomyDto[]> {
+    return getSubcategories(id);
+  }
+}

--- a/api/models/dto/taxonomyDto.ts
+++ b/api/models/dto/taxonomyDto.ts
@@ -1,0 +1,6 @@
+export default interface TaxonomyDto {
+  id: string;
+  description: string;
+  level: number;
+  parentCategoryId: string;
+}

--- a/api/models/scosApi/scosCategoryDto.ts
+++ b/api/models/scosApi/scosCategoryDto.ts
@@ -1,0 +1,7 @@
+import ScosSubcategoryDto from "./scosSubcategoryDto";
+
+export default interface ScosCategoryDto {
+  category: string;
+  categoryid: string;
+  subcat: ScosSubcategoryDto[];
+}

--- a/api/models/scosApi/scosSubcategoryDto.ts
+++ b/api/models/scosApi/scosSubcategoryDto.ts
@@ -1,0 +1,9 @@
+interface ScosSubcattermDto {
+  sterm: string;
+}
+
+export default interface ScosSubcategoryDto {
+  subcategory: string;
+  subcategoryid: string;
+  subcatterm: ScosSubcattermDto[];
+}

--- a/api/services/healthService.ts
+++ b/api/services/healthService.ts
@@ -1,8 +1,7 @@
 import { makeSCOSRequest } from './scosService';
 import HealthDto from '../models/dto/healthDto';
 import getLogger from '../utils/logger';
-
-const { AGENCIES_TABLE, CATEGORIES_TABLE } = process.env;
+import { AGENCIES_TABLE, CATEGORIES_TABLE } from '../utils/constants';
 
 const log = getLogger('healthService');
 

--- a/api/services/taxonomyService.ts
+++ b/api/services/taxonomyService.ts
@@ -1,0 +1,22 @@
+import { makeSCOSRequest } from './scosService';
+import getLogger from '../utils/logger';
+import TaxonomyDto from '../models/dto/taxonomyDto';
+import ScosSubcategoryDto from '../models/scosApi/scosSubcategoryDto';
+
+const { CATEGORIES_TABLE } = process.env;
+
+const log = getLogger('taxonomyService');
+
+async function getSubcategories(id: string): Promise<TaxonomyDto[]> {
+  log.debug(`Getting subcategories of category id ${id}`);
+  const response: ScosSubcategoryDto[] = await makeSCOSRequest(`SELECT subcat FROM ${CATEGORIES_TABLE} WHERE categoryid = '${id}'`);
+  return response.map((subcat: ScosSubcategoryDto): TaxonomyDto => ({
+    id: subcat.subcategoryid,
+    description: subcat.subcategory,
+    parentCategoryId: id,
+    // TODO: hardcoded bc I'm not sure if this is still available in the data
+    level: 1,
+  }));
+}
+
+export { getSubcategories };

--- a/api/services/taxonomyService.ts
+++ b/api/services/taxonomyService.ts
@@ -2,6 +2,7 @@ import { makeSCOSRequest } from './scosService';
 import getLogger from '../utils/logger';
 import TaxonomyDto from '../models/dto/taxonomyDto';
 import ScosSubcategoryDto from '../models/scosApi/scosSubcategoryDto';
+import ScosCategoryDto from '../models/scosApi/scosCategoryDto';
 
 const { CATEGORIES_TABLE } = process.env;
 
@@ -9,14 +10,18 @@ const log = getLogger('taxonomyService');
 
 async function getSubcategories(id: string): Promise<TaxonomyDto[]> {
   log.debug(`Getting subcategories of category id ${id}`);
-  const response: ScosSubcategoryDto[] = await makeSCOSRequest(`SELECT subcat FROM ${CATEGORIES_TABLE} WHERE categoryid = '${id}'`);
-  return response.map((subcat: ScosSubcategoryDto): TaxonomyDto => ({
+
+  const query = `SELECT subcat FROM ${CATEGORIES_TABLE} WHERE categoryid = '${id}'`;
+  const response: Pick<ScosCategoryDto, 'subcat'>[] = await makeSCOSRequest(query);
+
+  return response[0].subcat.map((subcat: ScosSubcategoryDto): TaxonomyDto => ({
     id: subcat.subcategoryid,
     description: subcat.subcategory,
     parentCategoryId: id,
     // TODO: hardcoded bc I'm not sure if this is still available in the data
     level: 1,
-  }));
+  }
+  ));
 }
 
 export { getSubcategories };

--- a/api/services/taxonomyService.ts
+++ b/api/services/taxonomyService.ts
@@ -3,8 +3,8 @@ import getLogger from '../utils/logger';
 import TaxonomyDto from '../models/dto/taxonomyDto';
 import ScosSubcategoryDto from '../models/scosApi/scosSubcategoryDto';
 import ScosCategoryDto from '../models/scosApi/scosCategoryDto';
-
-const { CATEGORIES_TABLE } = process.env;
+import { CATEGORIES_TABLE } from '../utils/constants';
+import { NotFoundError } from 'typescript-rest/dist/server/model/errors';
 
 const log = getLogger('taxonomyService');
 
@@ -13,6 +13,10 @@ async function getSubcategories(id: string): Promise<TaxonomyDto[]> {
 
   const query = `SELECT subcat FROM ${CATEGORIES_TABLE} WHERE categoryid = '${id}'`;
   const response: Pick<ScosCategoryDto, 'subcat'>[] = await makeSCOSRequest(query);
+
+  if (response?.length === 0) {
+    throw new NotFoundError(`Invalid category id ${id}`);
+  }
 
   return response[0].subcat.map((subcat: ScosSubcategoryDto): TaxonomyDto => ({
     id: subcat.subcategoryid,

--- a/api/utils/constants.ts
+++ b/api/utils/constants.ts
@@ -1,0 +1,3 @@
+export const AGENCIES_TABLE = 'handson_central_ohio__community_services_agencies'
+
+export const CATEGORIES_TABLE = 'handson_central_ohio__handson_central_ohio_agency_subcategory_terms'


### PR DESCRIPTION
**#68: Endpoint to get subcategories**

This endpoint gets subcategory info based on a category id. 
I validated that the fields I'm returning - found in the `taxonomyDto` - are the only ones currently being used by the UI. 