### PR TITLE
Use category ids

### DIFF
--- a/api/controllers/locationController.ts
+++ b/api/controllers/locationController.ts
@@ -8,7 +8,7 @@ import LocationDto from '../models/dto/locationDto';
 export default class LocationController {
   /**
    * Returns a list of locations.
-   * @param taxonomyId NOTE: this is the name of a category, e.g., 'Health Care"
+   * @param taxonomyId NOTE: this is a comma-separated list of category ids
    * @param limit
    * @param pageNumber
    */
@@ -20,6 +20,7 @@ export default class LocationController {
   ): Promise<LocationDto[]> {
     const limitInt = parseInt(limit, 10) || 500;
     const pageNumberInt = parseInt(pageNumber, 10);
-    return getLocations(taxonomyId, limitInt, pageNumberInt);
+    const taxonomyIds = taxonomyId.split(',');
+    return getLocations(taxonomyIds, limitInt, pageNumberInt);
   }
 }

--- a/api/controllers/locationController.ts
+++ b/api/controllers/locationController.ts
@@ -14,7 +14,7 @@ export default class LocationController {
    */
   @GET
   async getLocations(
-    @QueryParam('taxonomyId') taxonomyId: string,
+    @QueryParam('taxonomyId') taxonomyId: string = '',
     @QueryParam('limit') limit: string = '500',
     @QueryParam('pageNumber') pageNumber: string = '1'
   ): Promise<LocationDto[]> {

--- a/api/services/locationService.ts
+++ b/api/services/locationService.ts
@@ -64,13 +64,18 @@ async function getLocations(
     JOIN ${CATEGORIES_TABLE} c ON a.taxonomy.category = c.category 
     CROSS JOIN UNNEST(c.subcat) AS subcat
   WHERE
-    c.categoryid IN (${categories}) OR
-    subcat.subcategoryid IN (${categories})
+    a.taxonomy.sub_category = subcat.subcategory AND
+    (
+      c.categoryid IN (${categories}) OR
+      subcat.subcategoryid IN (${categories})
+    )
   LIMIT ${limit}`;
 
   const response: ScosAgencyDto[] = await makeSCOSRequest(query);
 
-  return response.map(mapToLocationDto).filter(notEmpty);
+  const mapped = response.map(mapToLocationDto).filter(notEmpty);
+  log.debug(`Returning ${mapped.length} locations`);
+  return mapped;
 }
 
 export { getLocations };

--- a/api/services/locationService.ts
+++ b/api/services/locationService.ts
@@ -1,7 +1,7 @@
 import { uniq } from 'lodash';
 import { makeSCOSRequest } from './scosService';
 import getLogger from '../utils/logger';
-import { AGENCIES_TABLE } from '../utils/constants';
+import { AGENCIES_TABLE, CATEGORIES_TABLE } from '../utils/constants';
 import LocationDto from '../models/dto/locationDto';
 import ScosAgencyDto from '../models/scosApi/scosAgencyDto';
 import { notEmpty } from '../utils/typeGuards';
@@ -48,19 +48,26 @@ function mapToLocationDto(agency: ScosAgencyDto): LocationDto | null {
 }
 
 async function getLocations(
-  taxonomyId: string,
+  taxonomyIds: string[],
   limit: number,
   pageNumber: number
 ): Promise<LocationDto[]> {
   log.debug(
-    `Getting locations by taxonomy id: ${taxonomyId}; limit: ${limit}; pageNumber: ${pageNumber}`
+    `Getting locations by taxonomy ids: ${taxonomyIds}; limit: ${limit}; pageNumber: ${pageNumber}`
   );
 
+  const categories = taxonomyIds.map(t => `'${t}'`).join(', ');
+
   const query = `
-    SELECT * FROM ${AGENCIES_TABLE}
-    WHERE taxonomy.category = '${taxonomyId}'
-    OR taxonomy.sub_category = '${taxonomyId}' 
-    LIMIT ${limit}`;
+  SELECT  DISTINCT a.* FROM 
+    ${AGENCIES_TABLE} a 
+    JOIN ${CATEGORIES_TABLE} c ON a.taxonomy.category = c.category 
+    CROSS JOIN UNNEST(c.subcat) AS subcat
+  WHERE
+    c.categoryid IN (${categories}) OR
+    subcat.subcategoryid IN (${categories})
+  LIMIT ${limit}`;
+
   const response: ScosAgencyDto[] = await makeSCOSRequest(query);
 
   return response.map(mapToLocationDto).filter(notEmpty);

--- a/api/services/locationService.ts
+++ b/api/services/locationService.ts
@@ -59,7 +59,7 @@ async function getLocations(
   const categories = taxonomyIds.map(t => `'${t}'`).join(', ');
 
   const query = `
-  SELECT  DISTINCT a.* FROM 
+  SELECT DISTINCT a.* FROM 
     ${AGENCIES_TABLE} a 
     JOIN ${CATEGORIES_TABLE} c ON a.taxonomy.category = c.category 
     CROSS JOIN UNNEST(c.subcat) AS subcat

--- a/api/services/taxonomyService.ts
+++ b/api/services/taxonomyService.ts
@@ -22,8 +22,7 @@ async function getSubcategories(id: string): Promise<TaxonomyDto[]> {
 
   return response[0].subcat.map(
     (subcat: ScosSubcategoryDto): TaxonomyDto => ({
-      // ids aren't available in the agencies table, so we're just passing around the string for now
-      id: subcat.subcategory,
+      id: subcat.subcategoryid,
       description: subcat.subcategory,
       parentCategoryId: id,
       // "categories" are level 1; "subcategories" are level 2

--- a/test/api/controllers/locationController.test.ts
+++ b/test/api/controllers/locationController.test.ts
@@ -8,14 +8,19 @@ describe('LocationController', () => {
 
   describe('.getLocations', () => {
     it('calls the service for the locations', async () => {
-      const category = '123';
+      const category1 = '123';
+      const category2 = '345';
       const limit = '250';
       const pageNumber = '2';
 
-      await locationController.getLocations(category, limit, pageNumber);
+      await locationController.getLocations(
+        `${category1},${category2}`,
+        limit,
+        pageNumber
+      );
 
       expect(getLocations).toHaveBeenCalledWith(
-        category,
+        [category1, category2],
         parseInt(limit, 10),
         parseInt(pageNumber, 10)
       );

--- a/test/api/services/locationService.test.ts
+++ b/test/api/services/locationService.test.ts
@@ -64,8 +64,11 @@ describe('locationService', () => {
     JOIN ${CATEGORIES_TABLE} c ON a.taxonomy.category = c.category 
     CROSS JOIN UNNEST(c.subcat) AS subcat
   WHERE
-    c.categoryid IN ('${category}') OR
-    subcat.subcategoryid IN ('${category}')
+    a.taxonomy.sub_category = subcat.subcategory AND
+    (
+      c.categoryid IN ('${category}') OR
+      subcat.subcategoryid IN ('${category}')
+    )
   LIMIT ${limit}`;
 
       await getLocations([category], limit, page);

--- a/test/api/services/taxonomyService.test.ts
+++ b/test/api/services/taxonomyService.test.ts
@@ -48,7 +48,7 @@ describe('taxonomyService', () => {
 
       const [taxonomy] = await getSubcategories(category);
 
-      expect(taxonomy.id).toEqual('test sub category');
+      expect(taxonomy.id).toEqual('test sub id');
       expect(taxonomy.description).toEqual('test sub category');
       expect(taxonomy.parentCategoryId).toEqual(category);
       expect(taxonomy.level).toEqual(2);


### PR DESCRIPTION
Use category ids instead of strings. Also, accept a list of taxonomyIds when getting locations (instead of only 1).