### PR TITLE
Fixed Scos location data error in code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_install:
   - npm ci
   - docker build -t mofb-api .
 
+install: skip
+
 script:
   - npm run tsc
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ notifications:
     - henderson.molly4@gmail.com
 
 before_install:
+  - npm ci
   - docker build -t mofb-api .
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ COPY ./package-lock.json .
 COPY ./swagger.config.json .
 COPY ./tsconfig.json .
 
-RUN npm install
 RUN npm run build
 RUN npx tsc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY ./package-lock.json .
 COPY ./swagger.config.json .
 COPY ./tsconfig.json .
 
+RUN npm install
 RUN npm run build
 RUN npx tsc
 

--- a/api/services/freshtrakService.ts
+++ b/api/services/freshtrakService.ts
@@ -27,6 +27,9 @@ async function getFTLocationData(
   freshTrakAgencies.set(5294, 849);
   freshTrakAgencies.set(11479, 502);
   freshTrakAgencies.set(10948, 606);
+  freshTrakAgencies.set(14137, 3536);
+  freshTrakAgencies.set(13978, 744);
+  freshTrakAgencies.set(13919, 691);
 
   const freshTrakAgencyID = freshTrakAgencies.get(parseInt(siteId, 10));
 

--- a/api/services/freshtrakService.ts
+++ b/api/services/freshtrakService.ts
@@ -14,7 +14,6 @@ async function getFTLocationData(
   freshTrakAgencies.set(5013, 106);
   freshTrakAgencies.set(11481, 803);
   freshTrakAgencies.set(13452, 200);
-  freshTrakAgencies.set(4205, 532);
   freshTrakAgencies.set(4863, 6);
   freshTrakAgencies.set(13796, 80);
   freshTrakAgencies.set(4985, 848);
@@ -24,7 +23,6 @@ async function getFTLocationData(
   freshTrakAgencies.set(13742, 549);
   freshTrakAgencies.set(6003, 3537);
   freshTrakAgencies.set(13549, 508);
-  freshTrakAgencies.set(5294, 849);
   freshTrakAgencies.set(11479, 502);
   freshTrakAgencies.set(10948, 606);
   freshTrakAgencies.set(14137, 3536);

--- a/api/services/locationService.ts
+++ b/api/services/locationService.ts
@@ -7,8 +7,23 @@ import ScosAgencyDto from '../models/scosApi/scosAgencyDto';
 import { notEmpty } from '../utils/typeGuards';
 import { getFTLocationData } from './freshtrakService';
 import freshtrakLocationDto from '../models/freshtrakAPI/freshtrakLocationDto';
+import ScosSiteDto from '../models/scosApi/scosSiteDto';
 
 const log = getLogger('locationService');
+
+function locationFix(agency: ScosAgencyDto, site: ScosSiteDto) {
+  // allows location fixes for incorrect 'hands on' data
+  const fixedLoc = {
+    latitude: site.latitude,
+    longitude: site.longitude,
+  };
+  // location fix for Reeb Center - 14137 is duplicate of 14346
+  if (agency.site_id === '14137') {
+    fixedLoc.latitude = 39.92491231;
+    fixedLoc.longitude = -82.98897764;
+  }
+  return fixedLoc;
+}
 
 async function mapToLocationDto(
   agency: ScosAgencyDto
@@ -42,6 +57,8 @@ async function mapToLocationDto(
     freshtrakData = await getFTLocationData(agency.site_id, address.zip);
   else freshtrakData = null;
 
+  const fixedLoc = locationFix(agency, site);
+
   return {
     id: agency.site_id,
     provider_id: agency.provider_id,
@@ -52,8 +69,8 @@ async function mapToLocationDto(
     phones,
     handicapAccessFlag,
     hours,
-    lat: `${site.latitude}`,
-    long: `${site.longitude}`,
+    lat: `${fixedLoc.latitude}`,
+    long: `${fixedLoc.longitude}`,
     freshtrakData,
   };
 }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
   - name: 'gcr.io/cloud-builders/git'
     args: ['fetch', '--unshallow']
   - name: 'gcr.io/cloud-builders/npm'
-    args: ['install']
+    args: ['ci']
   - name: 'gcr.io/cloud-builders/gcloud'
     args: ['app', 'deploy']
 timeout: '1600s'


### PR DESCRIPTION
Fixed Scos location data error in the locationService code.  There was duplicate location id data for two siteIds, 14346 and 14137.  This was preventing the FreshTrak links for South Side Roots Cafe (14137) from being displayed.  

Also added FreshTrak agency mappings for SouthSide, INPREM, and Greater Groveport increasing the number of deep links into FreshTrak events to 18 out of 56 locations. 

[
<img width="300" alt="Screen Shot 2020-12-11 at 12 21 37 PM" src="https://user-images.githubusercontent.com/31697968/101934954-4ac88100-3bac-11eb-9485-5f4f349f1388.png">
](url)